### PR TITLE
Report/blogpost deploy

### DIFF
--- a/reports/blogpost_stringency_measures/figures.py
+++ b/reports/blogpost_stringency_measures/figures.py
@@ -144,7 +144,7 @@ def delay_day_max_new_cases_per_100k_first_day_sim_max_stringency_map():
   )
 
 # %%
-stringency_df = pd.read_csv('/Users/merlos/devel/magicbox-reports/magicbox-reports/data/COVID-19_stats_stringency_index.csv')
+stringency_df = pd.read_csv('./data/COVID-19_stats_stringency_index.csv')
 
 # Get the dataframe with the stringency index of the countries to plot 
 stringency_plt_df = stringency_df.loc[(stringency_df['country_to_plot'] == True)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ geopandas==0.8.2
 gunicorn==20.0.4
 idna==2.10
 ipykernel==5.4.3
-ipython==7.19.0
+ipython==7.16.1
 ipython-genutils==0.2.0
 itsdangerous==1.1.0
 jedi==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ terminado==0.9.2
 testpath==0.4.4
 toml==0.10.2
 tornado==6.1
-traitlets==5.0.5
+traitlets==4.3.3
 urllib3==1.26.3
 wcwidth==0.2.5
 webencodings==0.5.1


### PR DESCRIPTION
Hi Andrea,
This PR includes changes to allow deploying in heroku. Mainly I had to change a couple of versions in requirements... I am not sure why those requirements are needed, I think you added them.
The app of this branch is deployed in:

https://magicbox-reports.herokuapp.com/reports/blogpost_stringency_measures/

If you open the post in heroku there are two issues.
1. It takes pretty much time to load the report :-(.  In the [performance section of dash docs]( https://dash.plotly.com/performance) they talk about memoizing...I am not sure we can do it without a companion external service.
2. While loading the report a white blank screen appears... that may confuse the user if it takes too much time to load. I am not sure how we can control that. It may require some research. 

 
