### PR TITLE
display loader while reports are being processed

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -28,3 +28,8 @@ a.report-item:hover {
   width: 100%;
 
 }
+
+/* Adds some padding in the loader for the articles */
+#page-content[data-dash-is-loading="true"] {
+  margin-top: 100px;
+}

--- a/index.py
+++ b/index.py
@@ -14,6 +14,8 @@ import about
 from config import config
 #from reports import report2, report3
 
+#import time
+
 app.renderer = '''
 var renderer = new DashRenderer({
     request_pre: (payload) => {
@@ -31,7 +33,14 @@ var renderer = new DashRenderer({
 app.layout = html.Div([
     dcc.Location(id='url', refresh=False),
     html.Div(className="", id='page-header'),
-    html.Div(className="doc container mt-4", id='page-content')
+    html.Div(className="loader", id='loader', children=[
+       dcc.Loading(
+            id="loading-report",
+            type="default",
+            color="#1CABE2", # UNICEF blue
+            children=html.Div(id="page-content")
+        ),
+    ])
 ])
 
 #
@@ -53,6 +62,7 @@ def display_header(search):
 @app.callback(Output('page-content', 'children'),
               [Input('url', 'pathname')])
 def display_contents(pathname):
+    #time.sleep(1000)
     reportName = re.search('^/reports/([\w\-]*)',pathname) 
     print('display_contents: pathname:' + pathname)
     if pathname == '/':


### PR DESCRIPTION
Fixes the absence of visual feedback while generating the report.

Using the native loading from Dash, displays a loader while the report is being generated.

More info: https://dash.plotly.com/dash-core-components/loading
